### PR TITLE
install s3 storage provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM matrixdotorg/synapse:v1.11.1
+
+RUN apk add --no-cache git &&\
+  pip install boto3 git+https://github.com/matrix-org/synapse-s3-storage-provider.git@a38b15b2a8588d734ebd43b9471aa9d6278feeb4
+
+VOLUME ["/data"]
+
+EXPOSE 8008/tcp 8009/tcp 8448/tcp
+
+ENTRYPOINT ["/start.py"]


### PR DESCRIPTION
The `matrixdotorg/synapse` image doesn't contain the s3 storage provider module or `boto3` which is required for the storage provider to work. Rather that downloading these dependencies at run time, let's bake them into an image on top of the official one.